### PR TITLE
Fix infinite loop issue in PktHeaderBitReader and bump version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   </prerequisites>
   <groupId>com.github.jai-imageio</groupId>  
     <artifactId>jai-imageio-jpeg2000</artifactId>
-    <version>1.3.1_CODICE_2</version>
+    <version>1.3.1_CODICE_3</version>
     <packaging>bundle</packaging>
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <jaiimageio.core.version>1.3.0</jaiimageio.core.version>
+      <jaiimageio.core.version>1.3.1</jaiimageio.core.version>
     </properties>
 
     <name>JPEG2000 support for Java Advanced Imaging Image I/O Tools API</name>

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KImageReader.java
@@ -488,6 +488,10 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
                              ImageReadParam param) throws IOException {
         checkIndex(imageIndex);
         processImageStarted(imageIndex);
+
+        if (param == null) {
+            param = getDefaultReadParam();
+        }
         param = new J2KImageReadParamJava(param);
 
         if (!ignoreMetadata) {

--- a/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/impl/J2KReadState.java
@@ -381,6 +381,7 @@ public class J2KReadState {
         WritableRaster raster = null;
 
         if (image == null) {
+            sampleModel = getSampleModel();
             raster = Raster.createWritableRaster(
                 sampleModel.createCompatibleSampleModel(destinationRegion.x +
                                                         destinationRegion.width,

--- a/src/main/java/com/github/jaiimageio/jpeg2000/package.html
+++ b/src/main/java/com/github/jaiimageio/jpeg2000/package.html
@@ -46,7 +46,7 @@ $State: Exp $
 Package containing the public classes used by the Sun JPEG 2000 plug-in for
 the Image I/O Framework.
 
-<h3><a name="ImageMetadata"</a>Image Metadata</h3>
+<h3><a name="ImageMetadata"/>Image Metadata</h3>
 
 <h4>Document Type Definition</h4>
 

--- a/src/main/java/jj2000/j2k/codestream/reader/PktDecoder.java
+++ b/src/main/java/jj2000/j2k/codestream/reader/PktDecoder.java
@@ -776,6 +776,15 @@ public class PktDecoder implements StdEntropyCoderOptions{
      * */
     public boolean readPktHead(int l,int r,int c,int p,CBlkInfo[][][] cbI,
                                int[] nb) throws IOException {
+        try {
+            return readPktHeadInternal(l, r, c, p, cbI, nb);
+        } catch (EOFException e) {
+            return true;
+        }
+    }
+
+    private boolean readPktHeadInternal(int l,int r,int c,int p,CBlkInfo[][][] cbI,
+        int[] nb) throws IOException {
 
         CBlkInfo ccb;
         int nSeg;                   // number of segment to read

--- a/src/main/java/jj2000/j2k/codestream/reader/PktHeaderBitReader.java
+++ b/src/main/java/jj2000/j2k/codestream/reader/PktHeaderBitReader.java
@@ -113,7 +113,7 @@ class PktHeaderBitReader {
      *
      * @exception IOException If an I/O error occurred
      *
-     * @exception EOFException If teh end of file has been reached
+     * @exception EOFException If the end of file has been reached
      *
      * */
     final int readBit() throws IOException {
@@ -134,6 +134,9 @@ class PktHeaderBitReader {
             else { // We had bit stuffing, nextbuf can not be 0xFF
                 bbuf = nextbbuf;
                 bpos = 7;
+            }
+            if (bbuf == -1) {
+                throw new EOFException("Could not read next bit. End of stream reached");
             }
         }
         return (bbuf >> --bpos) & 0x01;
@@ -187,6 +190,9 @@ class PktHeaderBitReader {
                 else { // We had bit stuffing, nextbuf can not be 0xFF
                     bbuf = nextbbuf;
                     bpos = 7;
+                }
+                if (bbuf == -1) {
+                    throw new EOFException("Could not read bits. End of stream reached");
                 }
             } while (n > bpos);
             // Get the last bits, if any

--- a/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
+++ b/src/main/java/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
@@ -156,8 +156,12 @@ public class ForwCompTransfSpec extends CompTransfSpec implements FilterTypes {
             return;
         }
 
-        if (param.equalsIgnoreCase("true"))
+        if (param.equalsIgnoreCase("true")) {
             param = "on";
+        }
+        else if (param.equalsIgnoreCase("false")) {
+            param = "off";
+        }
         // Parse argument
         StringTokenizer stk = new StringTokenizer(param);
         String word; // current word


### PR DESCRIPTION
Looked like there were some changes on https://github.com/jai-imageio/jai-imageio-jpeg2000 that our fork didn't have so I cherrypicked them over and included it with this pr. 
I think the only thing that needs to be reviewed is my commit https://github.com/codice/jai-imageio-jpeg2000/pull/3/commits/bd523bf26629d1a35b7b244049b0504b6fb84015

The changes I made make the methods behave in a way consistent with the javadoc on those methods.

@glenhein @dcruver @lessarderic Can you take a look at this.